### PR TITLE
remove google fonts

### DIFF
--- a/data/static/clockanddata.html
+++ b/data/static/clockanddata.html
@@ -13,9 +13,7 @@
 
     <!-- Custom fonts for this template -->
     <link href="/static/faf.css" rel="stylesheet" type="text/css">
-    <link
-        href="https://fonts.googleapis.com/css?family=Nunito:200,200i,300,300i,400,400i,600,600i,700,700i,800,800i,900,900i"
-        rel="stylesheet">
+
 
     <!-- Custom styles for this template -->
     <link href="/static/sb.css" rel="stylesheet">

--- a/data/static/dashboard.html
+++ b/data/static/dashboard.html
@@ -13,9 +13,7 @@
 
     <!-- Custom fonts for this template -->
     <link href="/static/faf.css" rel="stylesheet" type="text/css">
-    <link
-        href="https://fonts.googleapis.com/css?family=Nunito:200,200i,300,300i,400,400i,600,600i,700,700i,800,800i,900,900i"
-        rel="stylesheet">
+
 
     <!-- Custom styles for this template -->
     <link href="/static/sb.css" rel="stylesheet">

--- a/data/static/editor.html
+++ b/data/static/editor.html
@@ -13,9 +13,7 @@
 
     <!-- Custom fonts for this template -->
     <link href="/static/faf.css" rel="stylesheet" type="text/css">
-    <link
-        href="https://fonts.googleapis.com/css?family=Nunito:200,200i,300,300i,400,400i,600,600i,700,700i,800,800i,900,900i"
-        rel="stylesheet">
+
 
     <!-- Custom styles for this template -->
     <link href="/static/sb.css" rel="stylesheet">

--- a/data/static/wiegand.html
+++ b/data/static/wiegand.html
@@ -13,9 +13,7 @@
 
     <!-- Custom fonts for this template -->
     <link href="/static/faf.css" rel="stylesheet" type="text/css">
-    <link
-        href="https://fonts.googleapis.com/css?family=Nunito:200,200i,300,300i,400,400i,600,600i,700,700i,800,800i,900,900i"
-        rel="stylesheet">
+
 
     <!-- Custom styles for this template -->
     <link href="/static/sb.css" rel="stylesheet">


### PR DESCRIPTION
When Tick is used in offline scenario, downloading google fonts fails which delays UI loading.