### PR TITLE
Add HID Corp1000 35-bit and 48-bit Wiegand parsing & sending.

### DIFF
--- a/data/static/page-wiegand.js
+++ b/data/static/page-wiegand.js
@@ -13,6 +13,24 @@
 // 
 // You should have received a copy of the GNU General Public License
 
+// Corporate 1000 bit default layouts (override if the target uses a custom mapping)
+const C1000_LAYOUTS = {
+  35: { fcStart: 2, fcLen: 12, cnStart: 14, cnLen: 20 }, // Bits 3–14 (Company/Facility), 15–34 (Card #)
+  48: { fcStart: 2, fcLen: 22, cnStart: 24, cnLen: 23 }, // Bits 3–24 (Company/Facility), 25–47 (Card #)
+};
+
+// Helper to extract fields using the layout definition
+function decodeCorporate1000(binaryData, bitLength) {
+  const L = C1000_LAYOUTS[bitLength];
+  if (!L) return null;
+  const facilityCode = parseInt(binaryData.substring(L.fcStart, L.fcStart + L.fcLen), 2);
+  const cardNumber  = parseInt(binaryData.substring(L.cnStart, L.cnStart + L.cnLen), 2);
+  // For display, provide the raw hex (no preamble).
+  const paddedData  = parseInt(binaryData, 2).toString(16).toUpperCase();
+  const format = bitLength === 35 ? "C1000-35" : "C1000-48";
+  return { format, facilityCode, cardNumber, paddedData };
+}
+
 function decodeWiegand(rawData, bitLength) {
   let binaryData = parseInt(rawData, 16).toString(2).padStart(bitLength, '0');
   let format, facilityCode, cardNumber, preamble, paddedData;
@@ -25,6 +43,12 @@ function decodeWiegand(rawData, bitLength) {
       preamble = '000000100000000001';
       paddedData = parseInt((preamble + binaryData), 2).toString(16);
       break;
+    case 35: { // HID Corporate 1000 (common default layout. Configurable in C1000_LAYOUTS)
+      const c = decodeCorporate1000(binaryData, 35);
+      if (c) ({ format, facilityCode, cardNumber, paddedData } = c);
+      else { format = "C1000-35"; facilityCode = "N/A"; cardNumber = "N/A"; paddedData = "N/A"; }
+      break;
+    }
     case 37:
       format = "H10304";
       facilityCode = parseInt(binaryData.substring(1, 17), 2);
@@ -38,6 +62,12 @@ function decodeWiegand(rawData, bitLength) {
       cardNumber = parseInt(binaryData.substring(15, 45), 2);
       paddedData = 'N/A';
       break;
+    case 48: { // HID Corporate 1000 (48-bit variant. Configurable in C1000_LAYOUTS)
+      const c = decodeCorporate1000(binaryData, 48);
+      if (c) ({ format, facilityCode, cardNumber, paddedData } = c);
+      else { format = "C1000-48"; facilityCode = "N/A"; cardNumber = "N/A"; paddedData = "N/A"; }
+      break;
+    }
     default:
       format = "Unknown";
       facilityCode = "N/A";
@@ -48,28 +78,71 @@ function decodeWiegand(rawData, bitLength) {
   return { format, facilityCode, cardNumber, paddedData };
 }
 
+// Helpers to calculate even/odd parity
+const _evenParityBit = s => {
+    let count = 0;
+    for (let i = 0; i < s.length; i++) {
+        if (s[i] === '1') count++;
+    }
+    return count % 2 === 0 ? 0 : 1;
+};
+
+const _oddParityBit = s => {
+    let count = 0;
+    for (let i = 0; i < s.length; i++) {
+        if (s[i] === '1') count++;
+    }
+    return count % 2 === 1 ? 0 : 1;
+};
+
 function calculateWiegandParity(rawData, bitLength) {
-  let binaryData = parseInt(rawData, 16).toString(2).padStart(bitLength - 2, '0');
-  let evenParity, oddParity;
+  const isTriple = (bitLength === 35 || bitLength === 48);
+  const dataLen = bitLength - (isTriple ? 3 : 2);
+  const binaryData = parseInt(rawData, 16).toString(2).padStart(dataLen, '0');
+
+  let evenParity, oddParity, middleParity;
 
   switch (bitLength) {
-    case 26:
-      evenParity = binaryData.substring(0, 12).split('').filter(bit => bit === '1').length % 2 === 0 ? 0 : 1;
-      oddParity = binaryData.substring(12).split('').filter(bit => bit === '1').length % 2 === 1 ? 0 : 1;
+    case 26: {
+      const first = binaryData.substring(0, 12);
+      const last  = binaryData.substring(12);
+      evenParity  = _evenParityBit(first);
+      oddParity   = _oddParityBit(last);
       break;
-    case 37:
-      evenParity = binaryData.substring(0, 18).split('').filter(bit => bit === '1').length % 2 === 0 ? 0 : 1;
-      oddParity = binaryData.substring(18).split('').filter(bit => bit === '1').length % 2 === 1 ? 0 : 1;
+    }
+    case 37: {
+      const first = binaryData.substring(0, 18);
+      const last  = binaryData.substring(18);
+      evenParity  = _evenParityBit(first);
+      oddParity   = _oddParityBit(last);
       break;
-    case 46:
-      evenParity = binaryData.split('').filter(bit => bit === '1').length % 2 === 0 ? 0 : 1;
-      oddParity = binaryData.split('').filter(bit => bit === '1').length % 2 === 1 ? 0 : 1;
+    }
+    case 46: {
+      evenParity  = _evenParityBit(binaryData);
+      oddParity   = _oddParityBit(binaryData);
       break;
+    }
+    case 35: { // Corporate 1000 (35-bit, 3 parity bits)
+      const firstHalf = binaryData.substring(0, 16);
+      const lastHalf  = binaryData.substring(16);
+      evenParity   = _evenParityBit(firstHalf);
+      middleParity = _oddParityBit(binaryData);
+      oddParity    = _oddParityBit(lastHalf);
+      break;
+    }
+    case 48: { // Corporate 1000 (48-bit, 3 parity bits)
+      const firstPart = binaryData.substring(0, 22);
+      const lastPart  = binaryData.substring(22);
+      evenParity   = _evenParityBit(firstPart);
+      middleParity = _oddParityBit(binaryData);
+      oddParity    = _oddParityBit(lastPart);
+      break;
+    }
     default:
       return { error: "Unsupported bit length" };
   }
 
-  return { evenParity, oddParity };
+  return { evenParity, oddParity, middleParity };
 }
 
 function encodeWiegand(format, facilityCode, cardNumber) {
@@ -78,33 +151,52 @@ function encodeWiegand(format, facilityCode, cardNumber) {
 
   switch (format) {
     case "H10301":
-      bitLength = 26;
-      binaryData = facilityCode.toString(2).padStart(8, '0') + cardNumber.toString(2).padStart(16, '0');
+      bitLength  = 26;
+      binaryData = facilityCode.toString(2).padStart(8, '0')
+                 + cardNumber.toString(2).padStart(16, '0');
       break;
     case "H10304":
-      bitLength = 37;
-      binaryData = facilityCode.toString(2).padStart(16, '0') + cardNumber.toString(2).padStart(19, '0');
+      bitLength  = 37;
+      binaryData = facilityCode.toString(2).padStart(16, '0')
+                 + cardNumber.toString(2).padStart(19, '0');
       break;
     case "H800002":
-      bitLength = 46;
-      binaryData = facilityCode.toString(2).padStart(14, '0') + cardNumber.toString(2).padStart(30, '0');
+      bitLength  = 46;
+      binaryData = facilityCode.toString(2).padStart(14, '0')
+                 + cardNumber.toString(2).padStart(30, '0');
+      break;
+    case "C1000-35":
+      bitLength  = 35;
+      binaryData = facilityCode.toString(2).padStart(12, '0')
+                 + cardNumber.toString(2).padStart(20, '0');
+      break;
+    case "C1000-48":
+      bitLength  = 48;
+      binaryData = facilityCode.toString(2).padStart(22, '0')
+                 + cardNumber.toString(2).padStart(23, '0');
       break;
     default:
       return { error: "Unsupported format" };
   }
 
-  let { evenParity, oddParity } = calculateWiegandParity(parseInt(binaryData, 2).toString(16), bitLength);
-  let encodedData = evenParity.toString() + binaryData + oddParity.toString();
-  return parseInt(encodedData, 2).toString(16).toUpperCase() + ":" + bitLength.toString(10);
-}
+  const { evenParity, oddParity, middleParity } =
+    calculateWiegandParity(parseInt(binaryData, 2).toString(16), bitLength);
 
+  let encodedData;
+  if (bitLength === 35 || bitLength === 48) {
+    // 3 parity bits: [P1][P2] DATA [P3]
+    encodedData = `${evenParity}${middleParity}${binaryData}${oddParity}`;
+  } else {
+    // 2 parity bits: [P1] DATA [P2]
+    encodedData = `${evenParity}${binaryData}${oddParity}`;
+  }
+  return parseInt(encodedData, 2).toString(16).toUpperCase() + ":" + String(bitLength);
+}
 
 function send_wiegand(data) {
   $.get("/txid?v=" + data);
   alert(`Data sent: ${data}`);
 }
-
-
 
 function send_wiegand_raw(event) {
   event.preventDefault();

--- a/src_data/wiegand.html.j2
+++ b/src_data/wiegand.html.j2
@@ -29,6 +29,8 @@
                                     <option value="H10301">H10301</option>
                                     <option value="H10304">H10304</option>
                                     <option value="H800002">H800002</option>
+                                    <option value="C1000-35">C1000-35</option>
+                                    <option value="C1000-48">C1000-48</option>
                                 </select>
                                 <input id="wiegand_fc" placeholder="Facility code">
                                 <input id="wiegand_cn" placeholder="Card number">


### PR DESCRIPTION
**page-wiegand.js** 

- Added parsing and sending of HID Corp1000 standard 35-bit and 48-bit Wiegand data. 
- Corp1000 data layouts can be customized in C1000_LAYOUTS if target is using custom format Corp1000. 
- Created helper functions for calculating _evenParityBit and _oddParityBit and updated the calculatedWiegandParity function to use them for all formats.

**wiegand.html.j2**

- Added option values for C1000-35 and C1000-48 to the wiegand_format dropdown list.